### PR TITLE
[IMP] pyver_loans: GH#32 - Added validation error to the field Fully …

### DIFF
--- a/pyver_loans/models/loan_request.py
+++ b/pyver_loans/models/loan_request.py
@@ -118,6 +118,24 @@ class LoanRequest(models.Model):
                 ]
             )
 
+    @api.constrains("fully_paid_date")
+    def _validate_fully_paid_date(self):
+        """
+        Check if the fully paid date in the past. 
+        """
+        for record in self:
+            if record.fully_paid_date and record.fully_paid_date > fields.Date.today():
+                raise ValidationError("Fully paid date must be today or in the past.")
+    
+    @api.constrains("borrowed_date")
+    def _validate_borrowed_date(self):
+        """
+        Check if the borrowed date in the past. 
+        """
+        for record in self:
+            if record.borrowed_date and record.borrowed_date > fields.Date.today():
+                raise ValidationError("Borrowed date must be today or in the past.")
+
     @api.constrains("state")
     def _validate_related_loans(self):
         """

--- a/pyver_loans/views/loan_request_views.xml
+++ b/pyver_loans/views/loan_request_views.xml
@@ -59,7 +59,7 @@
                             <field name="loan_type_id" />
                             <field name="interest_rate" />
                             <field name="amount_due" />
-                            <field name="fully_paid_date" />
+                            <field name="fully_paid_date" readonly="state != 'fully_paid'" />
                         </group>
                         <group>
                             <field name="applied_date" readonly="1" />


### PR DESCRIPTION
…Paid Date and Borrowed Date when the user sets it to future.

**1. What this MR does / why we need it:**

- [for 32](https://github.com/crisaianvergara/pyver/issues/32)

**2. Related Screenshot (optional)**

- 

**3. CHANGELOG/Release Notes (optional)**

- Disabled `Fully Paid Date` when the status is not `fully_paid`.
-  `Borrowed Date`, and `Fully Paid Date` should not allow the selection of future dates.

Thanks for your MR, you're awesome! :+1:
